### PR TITLE
fix(link): 去重待添加网址拖拽处理

### DIFF
--- a/src/newtab/scenes/Link/LinkPanel.jsx
+++ b/src/newtab/scenes/Link/LinkPanel.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-refresh/only-export-components */
 import React from "react";
 import {
   useCreation,
@@ -17,6 +16,11 @@ import { ReactSortable } from "react-sortablejs";
 import LinkItem from "~/scenes/Link/LinkItem";
 import LinkTitle from "~/scenes/Link/LinkTitle";
 import { motion } from "framer-motion";
+import {
+  dedupeLinksByTimeKey,
+  hasMovedPendingLinks,
+  PENDING_LINK_PARENT_ID,
+} from "~/stores/pendingLinks.mjs";
 
 const { confirm } = Modal;
 
@@ -76,6 +80,12 @@ const LinkPanel = (props) => {
     updateList: [],
     isChange: false,
   }).current;
+
+  const refreshPendingListIfMoved = useMemoizedFn((links, parentId) => {
+    if (hasMovedPendingLinks(links, parentId)) {
+      tools.updateTimeKey();
+    }
+  });
 
 
   const addPanelToLinkItem$ = useEventEmitter();
@@ -167,8 +177,8 @@ const LinkPanel = (props) => {
           // 从数据库获取完整数据
           return link.getLinkByTimeKey(v.timeKey).then((linkData) => {
             if (linkData) {
-              // 如果是待添加网址（parentId === "000000"），直接更新数据库，不添加到列表
-              if (linkData.parentId === "000000") {
+              // 如果是待添加网址，直接更新数据库，不添加到列表
+              if (linkData.parentId === PENDING_LINK_PARENT_ID) {
                 return link.addPendingLinksToGroup(v.timeKey, key).then(() => {
                   // 更新成功，返回 null 表示不添加到列表（会通过刷新自动显示）
                   return null;
@@ -207,9 +217,6 @@ const LinkPanel = (props) => {
               pendingPromises.push(
                 link.getLinkByTimeKey(originalItem.timeKey).then((updatedLink) => {
                   if (updatedLink && updatedLink.parentId === key) {
-                    // 先添加到 link.list 和 cacheList，避免 diff 认为它是新项
-                    link.list.push(updatedLink);
-                    link.setCache();
                     return updatedLink;
                   }
                   return null;
@@ -224,17 +231,21 @@ const LinkPanel = (props) => {
         // 等待所有待添加网址更新完成
         Promise.all(pendingPromises).then((updatedPendingLinks) => {
           // 将更新后的待添加网址添加到 validItems
-          const allValidItems = [...validItems, ...updatedPendingLinks.filter(v => v !== null)];
+          const allValidItems = dedupeLinksByTimeKey([
+            ...validItems,
+            ...updatedPendingLinks.filter(v => v !== null),
+          ]);
           
           newPanel.push(...filterLinkList(allValidItems, key, false));
           link.list.push(...Array.from(newPanel));
 
           onChange(link.list);
+          refreshPendingListIfMoved(updatedPendingLinks, key);
           state.isChange = false;
         });
       });
     },
-    [link.getActiveID, link.titleLink.length, onChange, link]
+    [link.getActiveID, link.titleLink.length, onChange, link, refreshPendingListIfMoved]
   );
 
   // 复制全部网页
@@ -296,7 +307,7 @@ const LinkPanel = (props) => {
                 const updatePromises = newItems.map((newItem) => {
                   if (newItem.timeKey) {
                     return link.getLinkByTimeKey(newItem.timeKey).then((linkData) => {
-                      if (linkData && linkData.parentId === "000000") {
+                      if (linkData && linkData.parentId === PENDING_LINK_PARENT_ID) {
                         // 直接更新数据库
                         return link.addPendingLinksToGroup(newItem.timeKey, item.timeKey).then(() => {
                           // 更新成功后，从数据库中重新获取更新后的数据
@@ -323,6 +334,7 @@ const LinkPanel = (props) => {
                     link.list.push(...successfullyUpdated);
                     // 立即更新 cacheList，这样 updateData 的 diff 会认为它是更新而不是新增
                     link.setCache();
+                    refreshPendingListIfMoved(successfullyUpdated, item.timeKey);
                   }
                   
                   // 用更新后的数据替换 value 中的待添加网址
@@ -361,7 +373,7 @@ const LinkPanel = (props) => {
                   Promise.all(processedValue).then((resolvedValue) => {
                     setLinkItem(
                       item.timeKey,
-                      filterLinkList(resolvedValue, item.timeKey, false)
+                      filterLinkList(dedupeLinksByTimeKey(resolvedValue), item.timeKey, false)
                     );
                     state.updateList[item.timeKey] = false;
                   });
@@ -401,7 +413,6 @@ const LinkPanel = (props) => {
         </div>
       );
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [link.titleLink, link.linkForId, linkSpan, onUpdate, setLinkItem, onDelete, onDelPanel, onCopyAll]);
 
   const newPanelDom = useCreation(() => {

--- a/src/newtab/scenes/Link/TabList.jsx
+++ b/src/newtab/scenes/Link/TabList.jsx
@@ -127,6 +127,14 @@ const TabList = (props) => {
     cacheTime: 0,
   }).current;
 
+  const setPendingLinksCache = useMemoizedFn((links, cacheTime) => {
+    state.pendingLinksCache = links || [];
+    if (Number.isFinite(cacheTime)) {
+      state.cacheTime = cacheTime;
+    }
+    setPendingLinks(state.pendingLinksCache);
+  });
+
   const handleAddAll = useMemoizedFn(() => {
     Modal.confirm({
       title: "确认添加全部?",
@@ -188,6 +196,11 @@ const TabList = (props) => {
     if (cacheValid && state.tabListCache.windowId === id) {
       // 使用缓存数据
       setList(state.tabListCache.data);
+      link.getPendingLinks().then((links) => {
+        setPendingLinksCache(links);
+      }).catch((err) => {
+        console.error("Failed to refresh pending links from cache path:", err);
+      });
       setIsDataReady(true);
       return;
     }
@@ -200,11 +213,9 @@ const TabList = (props) => {
     ]).then(([tabListData, pendingData]) => {
       // 更新缓存
       state.tabListCache = { windowId: id, data: tabListData };
-      state.pendingLinksCache = pendingData;
-      state.cacheTime = now;
       
       setList(tabListData);
-      setPendingLinks(pendingData || []);
+      setPendingLinksCache(pendingData, now);
       setIsDataReady(true);
     }).catch((err) => {
       console.error("Failed to load tab list data:", err);
@@ -224,9 +235,7 @@ const TabList = (props) => {
     }
 
     link.getPendingLinks().then((links) => {
-      state.pendingLinksCache = links || [];
-      state.cacheTime = now;
-      setPendingLinks(state.pendingLinksCache);
+      setPendingLinksCache(links, now);
     }).catch((err) => {
       console.error("Failed to load pending links:", err);
       setPendingLinks([]);
@@ -252,11 +261,9 @@ const TabList = (props) => {
       const now = Date.now();
       // 更新缓存
       state.tabListCache = { windowId: id, data: tabListData };
-      state.pendingLinksCache = pendingData;
-      state.cacheTime = now;
       
       setList(tabListData);
-      setPendingLinks(pendingData || []);
+      setPendingLinksCache(pendingData, now);
       setIsDataReady(true);
     }).catch((err) => {
       console.error("Failed to refresh tab list data:", err);

--- a/src/newtab/stores/LinkStores.js
+++ b/src/newtab/stores/LinkStores.js
@@ -16,6 +16,11 @@ import {
 } from "~/utils";
 import { ensureFaviconForUrl } from "~/utils/favicon";
 import _ from "lodash";
+import {
+  PENDING_LINK_PARENT_ID,
+  dedupePendingLinks,
+  normalizePendingLinkUrl,
+} from "./pendingLinks.mjs";
 
 export default class LinkStore extends BaseStore {
   isInit = false;
@@ -49,19 +54,23 @@ export default class LinkStore extends BaseStore {
 
   updateNav() {
     return new Promise((resolve, reject) => {
-      this.rootStore.option.getHomeId().then((homeId) => {
-        this.getLinkByParentId([homeId], this.rootStore.option.showHide).then(
-          (res) => {
-            this.linkNav = res.sort((a, b) => {
-              return a.sort - b.sort;
-            });
-            resolve(this.linkNav);
-          }
-        );
-      });
-    }).catch((err) => {
-      reject(err);
-    })
+      this.rootStore.option.getHomeId()
+        .then((homeId) => {
+          this.getLinkByParentId([homeId], this.rootStore.option.showHide).then(
+            (res) => {
+              this.linkNav = res.sort((a, b) => {
+                return a.sort - b.sort;
+              });
+              resolve(this.linkNav);
+            }
+          ).catch((err) => {
+            reject(err);
+          });
+        })
+        .catch((err) => {
+          reject(err);
+        });
+    });
   }
 
   async getNav(refresh = false) {
@@ -391,15 +400,16 @@ export default class LinkStore extends BaseStore {
     this.rootStore.option.init();
   }
 
-  // 获取待添加网址列表（parentId 为 "000000"）
+  // 获取待添加网址列表
   getPendingLinks() {
     return new Promise((resolve, reject) => {
       db.link
         .where("parentId")
-        .equals("000000")
+        .equals(PENDING_LINK_PARENT_ID)
         .toArray()
         .then((res) => {
-          resolve(res || []);
+          const { uniqueLinks } = dedupePendingLinks(res || []);
+          resolve(uniqueLinks);
         })
         .catch((err) => {
           handleError(err, "LinkStore.getPendingLinks");
@@ -411,42 +421,54 @@ export default class LinkStore extends BaseStore {
   // 添加待添加网址
   addPendingLink(url, title) {
     return new Promise((resolve, reject) => {
-      // 检查是否已存在相同的 URL
-      db.link
-        .where("parentId")
-        .equals("000000")
-        .and((link) => link.url === url)
-        .first()
-        .then((existing) => {
-          if (existing) {
-            // 如果已存在，直接返回
-            resolve(existing);
-            return;
+      const normalizedUrl = normalizePendingLinkUrl(url);
+
+      if (!normalizedUrl) {
+        resolve(null);
+        return;
+      }
+
+      db.transaction("rw", db.link, async () => {
+        const pendingLinks = await db.link
+          .where("parentId")
+          .equals(PENDING_LINK_PARENT_ID)
+          .toArray();
+        const sameUrlLinks = pendingLinks.filter((link) => {
+          return normalizePendingLinkUrl(link.url) === normalizedUrl;
+        });
+
+        if (sameUrlLinks.length > 0) {
+          const { uniqueLinks, duplicateLinks } = dedupePendingLinks(sameUrlLinks);
+          const duplicateLinkIds = duplicateLinks
+            .map((link) => link.linkId)
+            .filter((linkId) => Number.isFinite(linkId));
+
+          if (duplicateLinkIds.length > 0) {
+            await db.link.where("linkId").anyOf(duplicateLinkIds).delete();
           }
-          // 获取当前待添加网址的数量，用于设置 sort
-          this.getPendingLinks().then((pendingLinks) => {
-            const newLink = {
-              title: title || url,
-              url: url,
-              parentId: "000000",
-              sort: pendingLinks.length,
-              timeKey: getID(),
-              hide: false,
-            };
-            db.link
-              .put(newLink)
-              .then((res) => {
-                this.rootStore.data.update();
-                resolve(res);
-              })
-              .catch((err) => {
-                handleError(err, "LinkStore.addPendingLink.put");
-                reject(err);
-              });
-          });
+
+          return uniqueLinks[0];
+        }
+
+        const { uniqueLinks } = dedupePendingLinks(pendingLinks);
+        const newLink = {
+          title: title || normalizedUrl,
+          url: normalizedUrl,
+          parentId: PENDING_LINK_PARENT_ID,
+          sort: uniqueLinks.length,
+          timeKey: getID(),
+          hide: false,
+        };
+
+        await db.link.put(newLink);
+        return newLink;
+      })
+        .then((res) => {
+          this.rootStore.data.update();
+          resolve(res);
         })
         .catch((err) => {
-          handleError(err, "LinkStore.addPendingLink.check");
+          handleError(err, "LinkStore.addPendingLink");
           reject(err);
         });
     });
@@ -458,7 +480,7 @@ export default class LinkStore extends BaseStore {
       db.link
         .where("timeKey")
         .equals(timeKey)
-        .and((link) => link.parentId === "000000")
+        .and((link) => link.parentId === PENDING_LINK_PARENT_ID)
         .delete()
         .then((res) => {
           this.rootStore.data.update();
@@ -477,7 +499,7 @@ export default class LinkStore extends BaseStore {
       db.link
         .where("timeKey")
         .equals(timeKey)
-        .and((link) => link.parentId === "000000")
+        .and((link) => link.parentId === PENDING_LINK_PARENT_ID)
         .first()
         .then((link) => {
           if (!link) {

--- a/src/newtab/stores/pendingLinks.mjs
+++ b/src/newtab/stores/pendingLinks.mjs
@@ -1,0 +1,94 @@
+export const PENDING_LINK_PARENT_ID = "000000";
+
+export const normalizePendingLinkUrl = (url) => {
+  if (typeof url !== "string") {
+    return "";
+  }
+  return url.trim();
+};
+
+const getSortValue = (link) => {
+  if (Number.isFinite(link?.sort)) {
+    return link.sort;
+  }
+  return Number.MAX_SAFE_INTEGER;
+};
+
+const getLinkIdValue = (link) => {
+  if (Number.isFinite(link?.linkId)) {
+    return link.linkId;
+  }
+  return Number.MAX_SAFE_INTEGER;
+};
+
+export const sortPendingLinks = (links = []) => {
+  return [...links].sort((a, b) => {
+    const sortDiff = getSortValue(a) - getSortValue(b);
+    if (sortDiff !== 0) {
+      return sortDiff;
+    }
+
+    const linkIdDiff = getLinkIdValue(a) - getLinkIdValue(b);
+    if (linkIdDiff !== 0) {
+      return linkIdDiff;
+    }
+
+    return String(a?.timeKey || "").localeCompare(String(b?.timeKey || ""));
+  });
+};
+
+export const dedupePendingLinks = (links = []) => {
+  const seenUrls = new Set();
+  const uniqueLinks = [];
+  const duplicateLinks = [];
+
+  sortPendingLinks(links).forEach((link) => {
+    const normalizedUrl = normalizePendingLinkUrl(link?.url);
+    if (!normalizedUrl) {
+      uniqueLinks.push(link);
+      return;
+    }
+
+    if (seenUrls.has(normalizedUrl)) {
+      duplicateLinks.push(link);
+      return;
+    }
+
+    seenUrls.add(normalizedUrl);
+    uniqueLinks.push({
+      ...link,
+      url: normalizedUrl,
+    });
+  });
+
+  return {
+    uniqueLinks,
+    duplicateLinks,
+  };
+};
+
+export const hasMovedPendingLinks = (links = [], parentId) => {
+  if (!parentId) {
+    return false;
+  }
+
+  return links.some((link) => {
+    return link && link.parentId === parentId;
+  });
+};
+
+export const dedupeLinksByTimeKey = (links = []) => {
+  const seenTimeKeys = new Set();
+
+  return links.filter((link) => {
+    const timeKey = link?.timeKey;
+    if (!timeKey) {
+      return true;
+    }
+    if (seenTimeKeys.has(timeKey)) {
+      return false;
+    }
+    seenTimeKeys.add(timeKey);
+    return true;
+  });
+};

--- a/src/newtab/stores/pendingLinks.test.mjs
+++ b/src/newtab/stores/pendingLinks.test.mjs
@@ -1,0 +1,87 @@
+import assert from "assert";
+import {
+  dedupeLinksByTimeKey,
+  PENDING_LINK_PARENT_ID,
+  dedupePendingLinks,
+  hasMovedPendingLinks,
+  normalizePendingLinkUrl,
+} from "./pendingLinks.mjs";
+
+assert.equal(normalizePendingLinkUrl(" https://example.com/a "), "https://example.com/a");
+assert.equal(normalizePendingLinkUrl(null), "");
+
+const links = [
+  {
+    linkId: 2,
+    timeKey: "second",
+    parentId: PENDING_LINK_PARENT_ID,
+    url: "https://example.com/a",
+    sort: 1,
+  },
+  {
+    linkId: 1,
+    timeKey: "first",
+    parentId: PENDING_LINK_PARENT_ID,
+    url: " https://example.com/a ",
+    sort: 0,
+  },
+  {
+    linkId: 3,
+    timeKey: "query",
+    parentId: PENDING_LINK_PARENT_ID,
+    url: "https://example.com/a?x=1",
+    sort: 2,
+  },
+  {
+    linkId: 4,
+    timeKey: "hash",
+    parentId: PENDING_LINK_PARENT_ID,
+    url: "https://example.com/a#section",
+    sort: 3,
+  },
+];
+
+const { uniqueLinks, duplicateLinks } = dedupePendingLinks(links);
+
+assert.deepEqual(
+  uniqueLinks.map((link) => link.timeKey),
+  ["first", "query", "hash"]
+);
+assert.deepEqual(
+  duplicateLinks.map((link) => link.timeKey),
+  ["second"]
+);
+
+assert.equal(
+  hasMovedPendingLinks(
+    [
+      { timeKey: "pending", parentId: PENDING_LINK_PARENT_ID },
+      { timeKey: "moved", parentId: "group-1" },
+      null,
+    ],
+    "group-1"
+  ),
+  true
+);
+
+assert.equal(
+  hasMovedPendingLinks(
+    [
+      { timeKey: "pending", parentId: PENDING_LINK_PARENT_ID },
+      { timeKey: "other", parentId: "group-2" },
+    ],
+    "group-1"
+  ),
+  false
+);
+
+assert.deepEqual(
+  dedupeLinksByTimeKey([
+    { timeKey: "same", title: "first" },
+    { timeKey: "same", title: "second" },
+    { title: "tab without timeKey 1" },
+    { title: "tab without timeKey 2" },
+    { timeKey: "other", title: "other" },
+  ]).map((link) => link.title),
+  ["first", "tab without timeKey 1", "tab without timeKey 2", "other"]
+);

--- a/src/newtab/view/Tower.jsx
+++ b/src/newtab/view/Tower.jsx
@@ -9,6 +9,7 @@ import { IconCloudUpload, IconCloudDownload } from "@tabler/icons-react";
 import { saveFavicon } from "~/db";
 import { db } from "~/db";
 import _ from "lodash";
+import { normalizePendingLinkUrl } from "~/stores/pendingLinks.mjs";
 
 const { useToken } = theme;
 
@@ -64,7 +65,7 @@ const Tower = ({ children }) => {
   const documentVisibility = useDocumentVisibility();
 
   const getTheme = useCallback(() => {
-    let isDark = option.getSystemTheme() === 'dark';;
+    let isDark = option.getSystemTheme() === 'dark';
 
     const t = {
       cssVar: true,
@@ -270,8 +271,21 @@ const Tower = ({ children }) => {
         runtime.storage.local.get(['pendingLinks'], (result) => {
           const pending = result.pendingLinks || [];
           if (pending.length > 0) {
+            const seenUrls = new Set();
+            const uniquePending = [];
+            pending.forEach((item) => {
+              const normalizedUrl = normalizePendingLinkUrl(item?.url);
+              if (!normalizedUrl || seenUrls.has(normalizedUrl)) {
+                return;
+              }
+              seenUrls.add(normalizedUrl);
+              uniquePending.push({
+                ...item,
+                url: normalizedUrl,
+              });
+            });
             // 批量添加待添加网址
-            Promise.all(pending.map((item) => {
+            Promise.all(uniquePending.map((item) => {
               if (item.url) {
                 return link.addPendingLink(item.url, item.title).catch((err) => {
                   console.error("[link] Failed to add pending link from storage", err);


### PR DESCRIPTION
当多个新标签页同时响应右键添加，或 Sortable clone 事件重复回放同一个拖拽项时，待添加网址可能重复出现或一次拖入两个标签。现在写入路径会在 Dexie 事务中去重，拖拽落地前也会按 timeKey 去重，并在移动后立即刷新待添加列表。

Closes #11

Constraint: 只对完整 URL 做 trim，不合并 query/hash 不同的网址
Rejected: 新增 Dexie schema/index | 这个修复不需要引入迁移
Confidence: high
Scope-risk: moderate
Tested: node src/newtab/stores/pendingLinks.test.mjs
Tested: npm run build
Not-tested: 浏览器手动拖拽回归